### PR TITLE
Buildエラーが出る不具合を修正

### DIFF
--- a/Editor/SoundSystem.Editor.asmdef
+++ b/Editor/SoundSystem.Editor.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:155d781af047a7e4bb1a93fc74761688"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
Editor.asmdef がビルド対象になっていたので除外しました。