### PR TITLE
asmdefのAuto Referencedを無効化

### DIFF
--- a/Editor/SoundSystem.Editor.asmdef
+++ b/Editor/SoundSystem.Editor.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/SoundSystem.asmdef
+++ b/SoundSystem.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
一般的な慣例に基づき、Auto Referencedを無効化しました。
破壊的変更になるので、適用するかどうかはお任せします（利用者側がasmdefを用意し、SoundSystemの参照を追加する必要があります）